### PR TITLE
Fix reference to undefined variable

### DIFF
--- a/src/js/page.js
+++ b/src/js/page.js
@@ -26,7 +26,7 @@ $(document).ready(() => {
     if ($figcaption) {
       $(this).attr('alt', $figcaption.text())
     } else {
-      $this.attr('alt', '')
+      $(this).attr('alt', '')
     }
   })
 


### PR DESCRIPTION
Replace an undefined variable with a jQuery-wrapped `this`. The original code appears to have a typo.