### PR TITLE
Add windows develop support

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ghost:2.30.2
     container_name: ghost
     volumes:
-      - $PWD/..:/var/lib/ghost/content/themes/liebling
+      - ./..:/var/lib/ghost/content/themes/liebling
       - ./ghost.db:/var/lib/ghost/content/data/ghost.db
     environment:
       - NODE_ENV=development

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "7zip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
+      "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -14449,6 +14455,12 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "win-node-env": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/win-node-env/-/win-node-env-0.4.0.tgz",
+      "integrity": "sha512-bf4TV/NOBEazlHJW/bOns7u2JaHe3f5bz8BYanm/xuqJ405NG9OK3VAI1Y2WvHJsAo4GMU8EYTHSh59Q3UfHvA==",
+      "optional": true
     },
     "window-size": {
       "version": "0.1.4",

--- a/src/package.json
+++ b/src/package.json
@@ -6,17 +6,18 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "get-database": "curl https://raw.githubusercontent.com/eddiesigner/ghost-db/master/ghost.db -o ghost.db",
-    "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "dev": "NODE_ENV=development node node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "NODE_ENV=development node node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "hot": "NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "docker-watch": "docker-compose up -d && node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && npm run zip",
-    "zip": "cd .. && zip -r liebling.zip ./* -x './src/*'"
+    "docker-watch": "docker-compose up -d && node node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "NODE_ENV=production node node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && npm run zip",
+    "zip": "cd .. && 7z a -r -x!.git -x!src liebling.zip *"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "7zip": "0.0.6",
     "browser-sync": "^2.26.7",
     "browser-sync-webpack-plugin": "^2.0.1",
     "ghost-cli": "^1.11.0",
@@ -37,5 +38,8 @@
     "slick-carousel": "^1.8.1",
     "stickybits": "^3.6.1",
     "tippy.js": "^4.0.1"
+  },
+  "optionalDependencies": {
+    "win-node-env": "^0.4.0"
   }
 }


### PR DESCRIPTION
This PR adds Windows develop support.
It just needed a `NODE_ENV` workaround with `win-node-env`.