### PR TITLE
Fix table in dark theme

### DIFF
--- a/src/sass/common/_themes.scss
+++ b/src/sass/common/_themes.scss
@@ -17,6 +17,8 @@
   --button-shadow-color-normal: rgba(108, 108, 108, 0.2);
   --button-shadow-color-hover: rgba(108, 108, 108, 0.3);
   --toggle-darkmode-button-color: #fff;
+  --table-background-color-odd: #fafafa;
+  --table-head-border-bottom: #e2e2e2;
 }
 
 [data-theme="dark"] {
@@ -37,6 +39,8 @@
   --button-shadow-color-normal: rgba(10, 10, 10, 0.5);
   --button-shadow-color-hover: rgba(10, 10, 10, 0.5);
   --toggle-darkmode-button-color: #efd114;
+  --table-background-color-odd: #050505;
+  --table-head-border-bottom: #1d1d1d;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -58,5 +62,7 @@
     --button-shadow-color-normal: rgba(10, 10, 10, 0.5);
     --button-shadow-color-hover: rgba(10, 10, 10, 0.5);
     --toggle-darkmode-button-color: #efd114;
+    --table-background-color-odd: #050505;
+    --table-head-border-bottom: #1d1d1d;
   }
 }

--- a/src/sass/common/_themes.scss
+++ b/src/sass/common/_themes.scss
@@ -25,10 +25,10 @@
   --background-color: #111;
   --primary-foreground-color: #ccc;
   --secondary-foreground-color: #fff;
-  --primary-subtle-color: #2c2fe6;
+  --primary-subtle-color: #fb5111;
   --secondary-subtle-color: #141920;
   --titles-color: #b4b4b4;
-  --link-color: #2c2fe6;
+  --link-color: #d6c6ae;
   --primary-border-color: #1d1d1d;
   --secondary-border-color: #0f0f0f;
   --article-shadow-normal: 0 4px 5px 5px rgba(0,0,0,0.1);
@@ -48,10 +48,10 @@
     --background-color: #111;
     --primary-foreground-color: #ccc;
     --secondary-foreground-color: #fff;
-    --primary-subtle-color: #2c2fe6;
+    --primary-subtle-color: #fb5111;
     --secondary-subtle-color: #141920;
     --titles-color: #b4b4b4;
-    --link-color: #2c2fe6;
+    --link-color: #d6c6ae;
     --primary-border-color: #1d1d1d;
     --secondary-border-color: #0f0f0f;
     --article-shadow-normal: 0 4px 5px 5px rgba(0,0,0,0.1);

--- a/src/sass/layouts/_post-content.scss
+++ b/src/sass/layouts/_post-content.scss
@@ -330,7 +330,7 @@
     }
 
     thead {
-      border-bottom: 1px solid #e2e2e2;
+      border-bottom: 1px solid var(--table-head-border-bottom);
 
       td {
         font-weight: 600;
@@ -338,8 +338,11 @@
     }
 
     tbody {
+      tr:nth-child(even) {
+        background-color: var(--background-color);
+      }
       tr:nth-child(odd) {
-        background-color: #fafafa;
+        background-color: var(--table-background-color-odd);
       }
     }
 


### PR DESCRIPTION
Hi,

i fixed the table in the dark theme. (I just used the inverted colors of the ligth theme, looks nice i think)
Previous:
<img width="687" alt="2019-11-23 14_08_10-Site - Liebling" src="https://user-images.githubusercontent.com/10356892/69479288-d7ff3300-0dfb-11ea-93db-57b2ce9a843e.png">
Now:
<img width="707" alt="2019-11-23 14_09_52-Site - Liebling" src="https://user-images.githubusercontent.com/10356892/69479298-ee0cf380-0dfb-11ea-9300-890976e1d3ad.png">

In the second commit i changed the link accent color and the subtle color to use also to the inverted ones of the light theme (`#04aeee` -> `#fb5111` and `#293951` -> `#d6c6ae`)

Previous:
<img width="303" alt="2019-11-23 14_04_25-Site - Liebling" src="https://user-images.githubusercontent.com/10356892/69479414-2d880f80-0dfd-11ea-8bc0-dd88a220edde.png">
Now:
<img width="320" alt="2019-11-23 14_04_55-Site - Liebling" src="https://user-images.githubusercontent.com/10356892/69479421-34af1d80-0dfd-11ea-9604-16f5c434638d.png">

You don't have to merge the second commit, if you like the colors as they are now.
I splitted the pull request in two commits so that you can easy just merge the table fix.

Regards,
D3473R