### PR TITLE
custom tags page

### DIFF
--- a/custom-tags.hbs
+++ b/custom-tags.hbs
@@ -1,0 +1,55 @@
+{{!< default }}
+<!-- masonry
+       ================================================== -->
+{{!-- Everything inside the #post tags pulls data from the post --}}
+{{#post}}
+<div class="main-wrap">
+    {{!-- Special header.hbs partial to generate the <header> tag --}}
+    {{> header background=feature_image}}
+    {{!-- Inject styles of the hero image to make it responsive --}}
+    {{> hero background=feature_image}}
+    <div class="m-hero__content" data-aos="fade-down">
+        <h1 class="m-hero-title bigger">{{title}}</h1>
+        {{#if custom_excerpt}}
+        <p class="m-hero-description">{{custom_excerpt}}</p>
+        {{/if}}
+    </div>
+    </section>
+    <main>
+        <article>
+            <div class="l-content">
+                <div class="l-wrapper in-post" data-aos="fade-up" data-aos-delay="300">
+                    <div class="l-post-content">
+                        <div class="pos-relative js-post-content">
+
+                            <div class="" data-aos="fade-down">
+                                <!--<h1 class="m-hero-title bigger">{{title}}</h1>-->
+                                {{content}}
+                                {{#get 'tags' limit='all' include='count.posts' order='count.posts desc'}}
+                                {{#foreach tags}}
+                                <img src='{{feature_image}}' alt="">
+                                <a href='{{ url }}'>
+                                    <h2>{{ name }} <small>({{ count.posts }})</small></h2>
+
+                                </a>
+                                {{/foreach}}
+                                {{/get}}
+                                {{#if custom_excerpt}}
+                                <p class="m-hero-description">{{custom_excerpt}}</p>
+                                {{/if}}
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </article>
+    </main>
+</div>
+{{/post}}
+
+</div>
+
+{{#contentFor "scripts"}}
+<script defer src="{{asset "js/page.js"}}"></script>
+{{/contentFor}}


### PR DESCRIPTION
This pull request is a suggestion to add a custom tags page.
What it does: 
_ Shows a list of #tags a blogger has as a list of topics.
_ Each of the topics might have its own image.
_ By clicking on a topic, a user sees the list of articles pertaining to that topic.

What would be cool to add:
_ Nicely formatted CSS styles (e.g. topics as a grid -> like on /authors/ page).