### PR TITLE
Fix an issue with loop partial ambiguity 

### DIFF
--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -46,11 +46,12 @@
   {{#is "post"}}
     </div>
   {{/is}}
-  {{else}}
+  {{^is "post"}}
     <header class="m-heading no-margin">
       <h3>{{t "No posts found"}}</h3>
       <p>
         {{t "Apparently there are no posts at the moment, check again later."}}
       </p>
     </header>
+  {{/is}}
 {{/foreach}}


### PR DESCRIPTION
There is an issue with the `{{else}}` clause at the end of the partial. As it is, it cannot be closed, since it matches the `{{is}}` right at the top and not the closest one. Closing will cause nothing to appear on the screen.

On the other hand, keeping it as it is prevents the use from adding content after {{else}} which should appear int eh main block. I propose to explicitly wrap the exception case in a negative `{{^is}} `block, which will have the same effect as else, but allow adding content after the block.