### PR TITLE
Modify hero template to handle large unsplash images

### DIFF
--- a/partials/hero.hbs
+++ b/partials/hero.hbs
@@ -8,25 +8,9 @@ for it, and apply those styles to the <header> tag.
 --}}
 
 {{#if background}}
-  {{#contentFor "herobackground"}}
-    <style>
-      .m-hero__picture {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .m-hero__picture img{
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-    </style>
-  {{/contentFor}}
-
   <section class="m-hero with-picture" data-aos="fade">
     <div class="m-hero__picture {{#is "post"}}in-post{{/is}}">
-      <img class="post-image"
-           srcset="{{img_url background size="s"}} 300w,
+      <img srcset="{{img_url background size="s"}} 300w,
             {{img_url background size="m"}} 600w,
             {{img_url background size="l"}} 1000w,
             {{img_url background size="xl"}} 2000w"

--- a/partials/hero.hbs
+++ b/partials/hero.hbs
@@ -2,30 +2,39 @@
 If the template in question has a background image, then we render responsive image styles
 for it, and apply those styles to the <header> tag.
 --}}
+{{!--
+If the template in question has a background image, then we render responsive image styles
+for it, and apply those styles to the <header> tag.
+--}}
 
 {{#if background}}
   {{#contentFor "herobackground"}}
-  <style>
-    .m-hero__picture {
-      background-image: url({{img_url background size='xl'}});
-    }
-  
-    @media(max-width: 1000px) {
+    <style>
       .m-hero__picture {
-        background-image: url({{img_url background size='l'}});
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
-    }
-  
-    @media(max-width: 600px) {
-      .m-hero__picture {
-        background-image: url({{img_url background size='m'}});
+      .m-hero__picture img{
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
       }
-    }
-  </style>
+    </style>
   {{/contentFor}}
 
   <section class="m-hero with-picture" data-aos="fade">
-    <div class="m-hero__picture {{#is "post"}}in-post{{/is}}"></div>
+    <div class="m-hero__picture {{#is "post"}}in-post{{/is}}">
+      <img class="post-image"
+           srcset="{{img_url background size="s"}} 300w,
+            {{img_url background size="m"}} 600w,
+            {{img_url background size="l"}} 1000w,
+            {{img_url background size="xl"}} 2000w"
+           sizes="(max-width: 600px) 600px, (max-width: 1000px) 1000px, 2000px"
+           src="{{img_url background size="l"}}"
+           alt="{{title}}"
+      />
+    </div>
 {{else}}
   <section class="m-hero no-picture {{#is "post"}}in-post{{/is}}" data-aos="fade">
 {{/if}}

--- a/src/sass/components/hero/_hero.scss
+++ b/src/sass/components/hero/_hero.scss
@@ -48,7 +48,16 @@
   &.in-post {
     opacity: 1;
   }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
+
 
 .m-hero__content {
   position: relative;


### PR DESCRIPTION
Fixes #286.

This is a modified implementation of the hero template, that takes into consideration an escaping issue in the `background-image` css attribute. With this version, everything looks similar visually, but Unsplash images load at most 2000px wide versions.