### PR TITLE
Hide subscription button and form if Members feature is disabled

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -31,7 +31,9 @@ into the {body} of the default.hbs template --}}
     {{#if @site.description}}
       <p class="m-hero-description bigger">{{@site.description}}</p>
     {{/if}}
+    {{#if @labs.members}}
     <a href="{{@site.url}}/newsletter" class="m-button filled js-newsletter">{{t "Subscribe"}}</a>
+    {{/if}}
   </div>
   </section>
   <div class="l-content">

--- a/post.hbs
+++ b/post.hbs
@@ -84,6 +84,7 @@ into the {body} of the default.hbs template --}}
           </div>
         </div>
         {{!-- Email subscribe form at the bottom of the page --}}
+        {{#if @labs.members}}
         <section class="m-subscribe-section js-newsletter">
           <div class="l-wrapper in-post">
             <div class="m-subscribe-section__content">
@@ -99,6 +100,7 @@ into the {body} of the default.hbs template --}}
             </div>
           </div>
         </section>
+        {{/if}}
         <section class="m-author">
           <div class="m-author__content">
             <div class="m-author__picture">

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ghost:
-    image: ghost:4.3.3
+    image: ghost:4.4.0
     container_name: ghost
     volumes:
       - ./..:/var/lib/ghost/content/themes/liebling:Z


### PR DESCRIPTION
We've disable the new Members feature, which allows people to subscribe to a newsletter and sign up for a membership. This PR hides the subscription-related button and form if the Members feature is disabled.