### PR TITLE
Add a "go to edit page" button

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -50,6 +50,10 @@ into the {body} of the default.hbs template --}}
             <div class="pos-relative js-post-content">
               <div class="m-share">
                 <div class="m-share__content js-sticky">
+                  <a href="{{url absolute='true'}}edit"
+                    class="m-icon-button filled in-share" target="_blank" rel="noopener" aria-label="Edit Page">
+                    <span class="icon-hidden" aria-hidden="true">Edit</span>  
+                  </a>
                   <a href="https://www.facebook.com/sharer/sharer.php?u={{url absolute='true'}}"
                     class="m-icon-button filled in-share" target="_blank" rel="noopener" aria-label="Facebook">
                     <span class="icon-facebook" aria-hidden="true"></span>


### PR DESCRIPTION
I just found out that it's possible to quickly jump to the edit page of the current blog post by adding "edit" at the end of the blog's URL, so I thought adding a link button that points to said URL should be a useful feature that slightly improves quality of life for blogger/editor