### PR TITLE
added content-cta + css

### DIFF
--- a/partials/content-cta.hbs
+++ b/partials/content-cta.hbs
@@ -1,0 +1,17 @@
+{{{html}}}
+<aside class="m-post-upgrade-cta">
+    <div class="m-post-upgrade-cta-content">
+        {{#has visibility="paid"}}
+            <h2>This post is for paying subscribers only</h2>
+        {{/has}}
+        {{#has visibility="members"}}
+            <h2>This post is for subscribers only</h2>
+        {{/has}}
+        {{#if @member}}
+            <a class="m-btn" data-portal="account/plans">Upgrade your account</a>
+        {{else}}
+            <a class="m-btn" data-portal="signup">Subscribe now</a>
+            <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
+        {{/if}}
+    </div>
+</aside>

--- a/src/sass/components/paywall/_content-cta.scss
+++ b/src/sass/components/paywall/_content-cta.scss
@@ -1,0 +1,58 @@
+.m-post-upgrade-cta-content,
+.m-post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+.m-post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+    background-color: var(--primary-subtle-color);
+}
+.m-post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+.m-post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+.m-post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+.m-post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+.m-post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+.m-post-upgrade-cta a.m-btn {
+    display: block;
+    background: #ffffff;
+    color: var(--primary-subtle-color);
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+.m-post-upgrade-cta a.m-btn:hover {
+    opacity: 0.92;
+}

--- a/src/sass/post.scss
+++ b/src/sass/post.scss
@@ -15,3 +15,4 @@
 @import "components/articles/recommended";
 @import "components/articles/recommended-articles";
 @import "components/articles/recommended-slider";
+@import "components/paywall/content-cta";


### PR DESCRIPTION
Added the custom-cta (paywall) to /partials and added complementary scss (_content-cta.scss). 
This allows for the paywall to use the recurring "primary-subtle-color" of the theme and adjust depending on light-/darkmode. 
I didn't commit the built files (namely: assets/css/post.css), let me know if I should add them.

## Before:
![paywall_ghost_accent](https://user-images.githubusercontent.com/69970159/134317687-0467fcd8-8d61-4b57-a4c2-25f0281c9433.png)

## After:
![paywall_primary_subtle_color](https://user-images.githubusercontent.com/69970159/134317772-7bbf3ee8-0f8f-470f-9e5e-1b285a2dd84f.png)



