### PR TITLE
Added RSS File for Yandex Turbo Pages and Some Dynamic Content Code

### DIFF
--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -6,9 +6,21 @@ Also it includes the big submenu.
 {{#if isSecondary}}
   <ul class="m-secondary-menu">
     {{#foreach navigation}}
-      <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}">
-        <a href="{{url absolute="true"}}">{{label}}</a>
-      </li>
+      {{#has slug="sign-up"}}
+        <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}">
+         <a href="{{url absolute="true"}}">
+           {{#if @member}}
+             {{t "Account"}}
+           {{else}}
+             {{label}}
+           {{/if}}
+         </a>
+        </li>
+      {{else}}
+        <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}">
+          <a href="{{url absolute="true"}}">{{label}}</a>
+        </li>
+      {{/has}}
     {{/foreach}}
   </ul>
 {{else}}

--- a/post.hbs
+++ b/post.hbs
@@ -93,7 +93,7 @@ into the {body} of the default.hbs template --}}
           </div>
         </div>
         {{!-- Email subscribe form at the bottom of the page --}}
-        {{#if @labs.members}}
+        {{#unless @member}}
           <section class="m-subscribe-section js-newsletter">
             <div class="l-wrapper in-post">
               <div class="m-subscribe-section__content">
@@ -109,7 +109,7 @@ into the {body} of the default.hbs template --}}
               </div>
             </div>
           </section>
-        {{/if}}
+        {{/unless}}
         <section class="m-author">
           <div class="m-author__content">
             <div class="m-author__picture">

--- a/yandex/rss.hbs
+++ b/yandex/rss.hbs
@@ -1,0 +1,59 @@
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/"
+    xmlns:yandex="http://news.yandex.ru" xmlns:turbo="http://turbo.yandex.ru" version="2.0">
+    <channel>
+        <title>
+            <![CDATA[ {{@site.title}} ]]>
+        </title>
+        <description>
+            <![CDATA[ {{@site.description}} ]]>
+        </description>
+        <language>en</language>
+        <link>{{@site.url}}</link>
+        <image>
+            <url>{{@site.url}}/favicon.png</url>
+            <title>{{@site.title}}</title>
+            <link>{{@site.url}}</link>
+        </image>
+        <lastBuildDate>{{date format="ddd, DD MMM YYYY HH:mm:ss ZZ"}}</lastBuildDate>
+        <atom:link href="{{@site.url}}" rel="self" type="application/rss+xml" />
+        <ttl>60</ttl>
+
+        {{#get "posts" limit="all" include="authors,tags"}}
+        {{#foreach posts}}
+        <item turbo="true">
+            <turbo:extendedHtml>true</turbo:extendedHtml>
+            <title>
+                <![CDATA[ {{title}} ]]>
+            </title>
+            <description>
+                <![CDATA[ {{excerpt}} ]]>
+            </description>
+            <link>{{url absolute="true"}}</link>
+            <turbo:source></turbo:source>
+            <turbo:topic></turbo:topic>
+            <guid isPermaLink="false">{{id}}</guid>
+            <category>
+                <![CDATA[ {{primary_tag.name}} ]]>
+            </category>
+            <author>
+                <![CDATA[ {{primary_author.name}} ]]>
+            </author>
+            <dc:creator>
+                <![CDATA[ {{primary_author.name}} ]]>
+            </dc:creator>
+            <pubDate>{{date format="ddd, DD MMM YYYY HH:mm:ss ZZ"}}</pubDate>
+            <media:content url="{{feature_image}}" medium="image" />
+            <content:encoded>
+                <![CDATA[ {{content}} ]]>
+            </content:encoded>
+            <yandex:related></yandex:related>
+            <turbo:content>
+                <![CDATA[ {{content}} ]]>
+            </turbo:content>
+        </item>
+        {{/foreach}}
+        {{/get}}
+
+    </channel>
+</rss>


### PR DESCRIPTION
This file is an RSS file with the necessary properties for Yandex Turbo Pages. You can add this in the Yandex Webmaster under the turbo pages section.
Turbo pages enable small snippets of your content to be shown on Yandex search results and it decreases load time on mobile devices.
https://yandex.com/dev/turbo/


You can access this file at: `https://<SITE-URL>/yandex/rss/`