### PR TITLE
change default RSS from '/rss' to feedly.com

### DIFF
--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -20,7 +20,7 @@ This footer template is shared across all the pages.
           <span class="icon-twitter" aria-hidden="true"></span>
         </a>
       {{/if}}
-      <a href="{{@site.url}}/rss" aria-label="RSS">
+      <a href="https://feedly.com/i/subscription/feed/{{@site.url}}/rss/" target="_blank" rel="noopener noreferrer" aria-label="RSS">
         <span class="icon-rss" aria-hidden="true"></span>
       </a>
     </nav>


### PR DESCRIPTION
By default, the '/rss' page was a 404 page in most instances.
Feedly.com offers a great experience for readers.