### PR TITLE
Support Native Search (Ghost V5)

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -96,6 +96,13 @@
       const ghostHost = "{{@site.url}}"
       // @license-end
     </script>
+
+    {{#if @custom.enable_native_search}}
+      <script>
+        const enableNativeSearch = "{{@custom.enable_native_search}}"
+      </script>
+    {{/if}}
+
     {{#if @custom.search_api_key}}
       <script>
         const ghostSearchApiKey = "{{@custom.search_api_key}}"

--- a/default.hbs
+++ b/default.hbs
@@ -96,13 +96,6 @@
       const ghostHost = "{{@site.url}}"
       // @license-end
     </script>
-
-    {{#if @custom.enable_native_search}}
-      <script>
-        const enableNativeSearch = "{{@custom.enable_native_search}}"
-      </script>
-    {{/if}}
-
     {{#if @custom.search_api_key}}
       <script>
         const ghostSearchApiKey = "{{@custom.search_api_key}}"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
       "dark_mode_logo": {
         "type": "image"
       },
+      "enable_native_search": {
+        "type": "boolean",
+        "default": false
+      },
       "search_api_key": {
         "type": "text"
       },

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -19,15 +19,9 @@ This header template is shared across all the pages.
         {{@site.title}}
       </a>
     {{/if}}
-    <button class="m-icon-button in-mobile-topbar js-open-search" aria-label="{{t "Open search"}}">
+    <button class="m-icon-button in-mobile-topbar {{^if @custom.enable_native_search}}js-open-search{{/if}}" {{#if @custom.enable_native_search}}data-ghost-search{{/if}} aria-label="{{t "Open search"}}">
       <span class="icon-search" aria-hidden="true"></span>
     </button>
-    {{#if @custom.enable_native_search}}
-      <button class="m-icon-button in-mobile-topbar" data-ghost-search aria-label="{{t "Open search"}}">
-        <span class="icon-search" aria-hidden="true"></span>
-      </button>
-    {{/if}}
-
   </div>
 
   <div class="m-menu js-menu">
@@ -124,14 +118,9 @@ This header template is shared across all the pages.
             </ul>
           </nav>
           <div class="m-nav__right">
-            <button class="m-icon-button in-menu-main js-open-search" aria-label="{{t "Open search"}}">
+            <button class="m-icon-button in-menu-main {{^if @custom.enable_native_search}}js-open-search{{/if}}" {{#if @custom.enable_native_search}}data-ghost-search{{/if}} aria-label="{{t "Open search"}}">
               <span class="icon-search" aria-hidden="true"></span>
             </button>
-            {{#if @custom.enable_native_search}}
-              <button class="m-icon-button in-menu-main" data-ghost-search aria-label="{{t "Open search"}}">
-                <span class="icon-search" aria-hidden="true"></span>
-              </button>
-            {{/if}}
             <div class="m-toggle-darkmode js-tooltip" data-tippy-content="{{t "Toggle dark mode"}}" tabindex="0">
               <label for="toggle-darkmode" class="sr-only">
                 {{t "Toggle dark mode"}}

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -22,6 +22,12 @@ This header template is shared across all the pages.
     <button class="m-icon-button in-mobile-topbar js-open-search" aria-label="{{t "Open search"}}">
       <span class="icon-search" aria-hidden="true"></span>
     </button>
+    {{#if @custom.enable_native_search}}
+      <button class="m-icon-button in-mobile-topbar" data-ghost-search aria-label="{{t "Open search"}}">
+        <span class="icon-search" aria-hidden="true"></span>
+      </button>
+    {{/if}}
+
   </div>
 
   <div class="m-menu js-menu">
@@ -121,6 +127,11 @@ This header template is shared across all the pages.
             <button class="m-icon-button in-menu-main js-open-search" aria-label="{{t "Open search"}}">
               <span class="icon-search" aria-hidden="true"></span>
             </button>
+            {{#if @custom.enable_native_search}}
+              <button class="m-icon-button in-menu-main" data-ghost-search aria-label="{{t "Open search"}}">
+                <span class="icon-search" aria-hidden="true"></span>
+              </button>
+            {{/if}}
             <div class="m-toggle-darkmode js-tooltip" data-tippy-content="{{t "Toggle dark mode"}}" tabindex="0">
               <label for="toggle-darkmode" class="sr-only">
                 {{t "Toggle dark mode"}}


### PR DESCRIPTION
Support Ghost official Native Search feature. #462

* Add new custom setting `enable_native_search (Enable native search)` in Site-wide group
* New Native Search button keep the same style and position as the old button
* Still keep the old Theme Search feature

<img width="1306" alt="screenshot 2022-08-16 5 23 16pm" src="https://user-images.githubusercontent.com/4946624/184847961-1e2bcf0c-c6ac-49ae-8f2a-f0ee45fdd849.png">
