### PR TITLE
Sort "Related posts" by recently published

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -37,7 +37,7 @@ into the {body} of the default.hbs template --}}
       {{/if}}
     {{/if}}
   {{/post}}
-  
+
   <article>
     <div class="l-content in-post">
       {{!-- Everything inside the #post tags pulls data from the post --}}
@@ -177,7 +177,7 @@ into the {body} of the default.hbs template --}}
       {{/post}}
       {{!-- Related posts --}}
       {{#if post.tags.length}}
-        {{#get "posts" limit="3" filter="tags:[{{post.tags}}]+id:-{{post.id}}" include="tags,authors" as |related|}}
+        {{#get "posts" limit="3" filter="tags:[{{post.tags}}]+id:-{{post.id}}" include="tags,authors" order="published_at desc" as |related|}}
           {{#if related}}
             <section class="m-recommended">
               <div class="l-wrapper in-recommended">

--- a/post.hbs
+++ b/post.hbs
@@ -37,7 +37,7 @@ into the {body} of the default.hbs template --}}
       {{/if}}
     {{/if}}
   {{/post}}
-
+  
   <article>
     <div class="l-content in-post">
       {{!-- Everything inside the #post tags pulls data from the post --}}


### PR DESCRIPTION
Our site was continuously showing old posts in this section and this change allows us to show recent related posts. 