### PR TITLE
Automatically set the theme based on system color scheme (dark or light)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -76,6 +76,22 @@ $(() => {
     }
   };
 
+  const getDefaultSystemColorScheme = () => {
+    if (!currentSavedTheme) {
+      if (!window.matchMedia) return;
+
+      const darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+
+      if (darkMedia.matches) {
+        $('html').attr('data-theme', 'dark');
+      }
+
+      darkMedia.addEventListener('change', (event) => {
+        $('html').attr('data-theme', event.matches ? 'dark' : 'light');
+      });
+    }
+  };
+
   const getAllPosts = (host, key) => {
     const api = new GhostContentAPI({
       url: host,
@@ -327,4 +343,5 @@ $(() => {
 
   tryToRemoveNewsletter();
   trySearchFeature();
+  getDefaultSystemColorScheme();
 });


### PR DESCRIPTION
- Load the theme based on the system scheme (dark or light) by default
- Listen to the system color scheme change
- If the user chooses a theme directly (click on toggle icon), disable the listener and keep the user's choice

![preview](https://github.com/eddiesigner/liebling/assets/22357579/0018ce5a-3fa4-437f-bad2-c5afd0b17792)
