### PR TITLE
Added a script for new docker compose plugin version

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -42,6 +42,69 @@ into the {body} of the default.hbs template --}}
   </section>
 </main>
 
+<article>
+  <div class="m-showcase-container">
+    <div class="m-showcase-item">
+      <div class="m-showcase-item-text">
+        <h1>
+          I love to transform ideas into code! 
+        </h1>
+        <p>
+          As a dedicated software developer specializing in frontend development, I have a solid foundation in HTML, CSS, and JavaScript. I bring websites and applications to life with seamless user experiences. I am conversant with the React library and well capable of leveraging its power to build dynamic and interactive user interfaces. Beyond my experience in frontend, I’ve also ventured into the exciting realm of the Internet of Things, applying my skills to connect physical devices and create innovative solutions.
+        </p>
+      </div>
+    </div>
+    <div class="m-showcase-item">
+      <img class="m-showcase-item-image" src="https://www.neelaundhia.com/content/images/static/code-typing.svg">
+    </div>
+  </div>
+  <div class="m-showcase-container m-showcase-container-reverse">
+    <div class="m-showcase-item">
+      <img class="m-showcase-item-image" src="https://www.neelaundhia.com/content/images/static/server-configuration.svg">
+    </div>
+    <div class="m-showcase-item">
+      <div class="m-showcase-item-text">
+        <h1>
+          I love to transform ideas into code! 
+        </h1>
+        <p>
+          As a dedicated software developer specializing in frontend development, I have a solid foundation in HTML, CSS, and JavaScript. I bring websites and applications to life with seamless user experiences. I am conversant with the React library and well capable of leveraging its power to build dynamic and interactive user interfaces. Beyond my experience in frontend, I’ve also ventured into the exciting realm of the Internet of Things, applying my skills to connect physical devices and create innovative solutions.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="m-showcase-container">
+    <div class="m-showcase-item">
+      <div class="m-showcase-item-text">
+        <h1>
+          I love to transform ideas into code! 
+        </h1>
+        <p>
+          As a dedicated software developer specializing in frontend development, I have a solid foundation in HTML, CSS, and JavaScript. I bring websites and applications to life with seamless user experiences. I am conversant with the React library and well capable of leveraging its power to build dynamic and interactive user interfaces. Beyond my experience in frontend, I’ve also ventured into the exciting realm of the Internet of Things, applying my skills to connect physical devices and create innovative solutions.
+        </p>
+      </div>
+    </div>
+    <div class="m-showcase-item">
+      <img class="m-showcase-item-image" src="https://www.neelaundhia.com/content/images/static/smart-home.svg">
+    </div>
+  </div>
+  <div class="m-showcase-container m-showcase-container-reverse">
+    <div class="m-showcase-item">
+      <img class="m-showcase-item-image" src="https://www.neelaundhia.com/content/images/static/climate-change.svg">
+    </div>
+    <div class="m-showcase-item">
+      <div class="m-showcase-item-text">
+        <h1>
+          I love to transform ideas into code! 
+        </h1>
+        <p>
+          As a dedicated software developer specializing in frontend development, I have a solid foundation in HTML, CSS, and JavaScript. I bring websites and applications to life with seamless user experiences. I am conversant with the React library and well capable of leveraging its power to build dynamic and interactive user interfaces. Beyond my experience in frontend, I’ve also ventured into the exciting realm of the Internet of Things, applying my skills to connect physical devices and create innovative solutions.
+        </p>
+      </div>
+    </div>
+  </div>
+</article>
+
 {{!-- The #contentFor helper here will send everything inside it up to the matching #block helper found in default.hbs --}}
 {{#contentFor "scripts"}}
   <script defer src="{{asset "js/home.js"}}"></script>

--- a/home.hbs
+++ b/home.hbs
@@ -1,0 +1,48 @@
+{{!--
+This template is used for the index page.
+It can be used also as the home page or the default page.
+--}}
+
+{{!-- This block preloads specific assets for the index page --}}
+{{#contentFor "preload"}}
+  <link rel="preload" href="{{asset "css/home.css"}}" as="style" />
+  <link rel="preload" href="{{asset "css/listing.css"}}" as="style" />
+  <link rel="preload" href="{{asset "js/home.js"}}" as="script" />
+{{/contentFor}}
+
+{{!-- This block loads specific styles for the index page --}}
+{{#contentFor "styles"}}
+  <link rel="stylesheet" type="text/css" href="{{asset "css/home.css"}}" media="screen" />
+  <link rel="stylesheet" type="text/css" href="{{asset "css/listing.css"}}" media="screen" />
+{{/contentFor}}
+
+{{!-- The tag below means: insert everything in this file
+into the {body} of the default.hbs template --}}
+{{!< default}}
+
+{{!-- Special header.hbs partial to generate the <header> tag --}}
+{{> header background=@site.cover_image}}
+
+<main class="main-wrap">
+  {{!-- Inject styles of the hero image to make it responsive --}}
+  {{> hero background=@site.cover_image}}
+  <div class="m-hero__content" data-animate="fade-down">
+    <h1 class="m-hero-title bigger">{{@site.title}}</h1>
+    {{#if @site.description}}
+      <p class="m-hero-description bigger">{{@site.description}}</p>
+    {{/if}}
+    {{#if @custom.use_custom_cta}}
+      <a href="{{@custom.custom_cta_url}}" class="m-button filled">{{@custom.custom_cta_text}}</a>
+    {{else}}
+      {{#if @site.members_enabled}}
+        <a href="{{@site.url}}/newsletter" class="m-button filled js-newsletter">{{t "Subscribe"}}</a>
+      {{/if}}
+    {{/if}}
+  </div>
+  </section>
+</main>
+
+{{!-- The #contentFor helper here will send everything inside it up to the matching #block helper found in default.hbs --}}
+{{#contentFor "scripts"}}
+  <script defer src="{{asset "js/home.js"}}"></script>
+{{/contentFor}}

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
     "watch": "npx mix watch",
     "hot": "npx mix watch --hot",
     "docker-watch": "concurrently --names 'DOCKER,WEBPACK' --prefix-colors 'yellow,magenta' --kill-others \"docker-compose up\" \"npm run watch\"",
+    "docker-watch-new": "concurrently --names 'DOCKER,WEBPACK' --prefix-colors 'yellow,magenta' --kill-others \"docker compose up\" \"npm run watch\"",
     "podman-watch": "podman-compose up -d && npm run watch",
     "deploy": "npm run production && node deploy/index.js",
     "production": "npm run build && npm run zip",

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -36,6 +36,7 @@
 @import "components/hero/description";
 @import "components/hero/social";
 @import "components/hero/stats";
+@import "components/showcase/introduction";
 @import "components/heading/heading";
 @import "components/heading/title";
 @import "components/heading/description";

--- a/src/sass/components/hero/_hero.scss
+++ b/src/sass/components/hero/_hero.scss
@@ -1,14 +1,15 @@
 .m-hero {
   position: relative;
   flex-direction: column;
-  min-height: 365px;
+  // min-height: 365px;
+  min-height: 100vh;
   overflow: hidden;
   padding: 100px 0 75px;
   background-color: var(--secondary-subtle-color);
   @extend .content-centered;
 
   @include respond-to('medium') {
-    min-height: 400px;
+    // min-height: 400px;
     padding: 150px 0 75px;
   }
 
@@ -16,13 +17,13 @@
     color: $white;
     background-color: $black;
 
-    @include respond-to('medium') {
-      min-height: 450px;
-    }
+    // @include respond-to('medium') {
+    //   min-height: 450px;
+    // }
 
-    @include respond-to('extra-large') {
-      min-height: 565px;
-    }
+    // @include respond-to('extra-large') {
+    //   min-height: 565px;
+    // }
 
     .m-hero-title {
       color: $white;

--- a/src/sass/components/showcase/_introduction.scss
+++ b/src/sass/components/showcase/_introduction.scss
@@ -1,0 +1,40 @@
+.m-showcase-container {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  text-align: justify;
+  @include respond-to('large') {
+    padding: 0px 40px;
+  }
+}
+
+.m-showcase-container-reverse {
+  flex-direction: column-reverse;
+  @include respond-to('large') {
+    flex-direction: row;
+  }
+}
+
+.m-showcase-item {
+  display: flex;
+  flex-basis: 100%;
+  align-items: center;
+  @include respond-to('large') {
+    flex-basis: 50%;
+  }
+}
+
+.m-showcase-item-text {
+  padding: 40px 40px;
+}
+
+.m-showcase-item-image {
+  display: block;
+  margin: auto;
+  padding: 20px;
+  max-width: 100%;
+  @include respond-to('large') {
+    max-width: 512px;
+  }
+}

--- a/src/sass/components/showcase/_introduction.scss
+++ b/src/sass/components/showcase/_introduction.scss
@@ -4,14 +4,14 @@
   flex-wrap: wrap;
   justify-content: space-around;
   text-align: justify;
-  @include respond-to('large') {
+  @include respond-to("large") {
     padding: 0px 40px;
   }
 }
 
 .m-showcase-container-reverse {
   flex-direction: column-reverse;
-  @include respond-to('large') {
+  @include respond-to("large") {
     flex-direction: row;
   }
 }
@@ -20,7 +20,7 @@
   display: flex;
   flex-basis: 100%;
   align-items: center;
-  @include respond-to('large') {
+  @include respond-to("large") {
     flex-basis: 50%;
   }
 }
@@ -30,7 +30,10 @@
 }
 
 .m-showcase-item-text > p {
-  font-size: 1.4rem;
+  font-size: 1rem;;
+  @include respond-to("large") {
+    font-size: 1.4rem;
+  }
 }
 
 .m-showcase-item-image {
@@ -38,7 +41,7 @@
   margin: auto;
   padding: 20px;
   width: 80vw;
-  @include respond-to('large') {
+  @include respond-to("large") {
     max-width: 512px;
   }
 }

--- a/src/sass/components/showcase/_introduction.scss
+++ b/src/sass/components/showcase/_introduction.scss
@@ -26,14 +26,18 @@
 }
 
 .m-showcase-item-text {
-  padding: 40px 40px;
+  padding: 0px 40px;
+}
+
+.m-showcase-item-text > p {
+  font-size: 1.4rem;
 }
 
 .m-showcase-item-image {
   display: block;
   margin: auto;
   padding: 20px;
-  max-width: 100%;
+  width: 80vw;
   @include respond-to('large') {
     max-width: 512px;
   }


### PR DESCRIPTION
The latest version of docker engine for Ubuntu installed as suggested by the official guide [https://docs.docker.com/engine/install/ubuntu/](https://docs.docker.com/engine/install/ubuntu/) doesn't use `docker-compose` command. Instead, compose is shipped as a plugin with docker and is invoked with the `docker compose` command. I have added a new script called `docker-watch-new` which accommodates for this.