### PR TITLE
fix: remove gaps between collapsible menu and header on desktop layout

### DIFF
--- a/src/sass/components/header/_menu.scss
+++ b/src/sass/components/header/_menu.scss
@@ -29,7 +29,7 @@
     opacity: 1 !important;
     overflow: initial;
     background-color: transparent;
-    @include transform(translate3d(0, 0, 0) !important);
+    transform: unset;
   }
 }
 


### PR DESCRIPTION
I discovered that on desktop, the collapsible menu doesn't positioned correctly, which is caused by `scale(1.2)` in `.m-menu` where `media: medium`. Although this attribute was overwritten by `translate3d (0,0,0)` which was compiled to `translateZ(0px)`, it doesn't seem to be overwritten correctly.

Therefore I changed the `translate3d` to `unset`. And tested on Chrome 120.0.6099.234; Firefox 122.0; Safari 17.1.2, and all worked as expected.

<img width="1673" alt="Capture d’écran, le 2024-01-24 à 17 41 19" src="https://github.com/eddiesigner/liebling/assets/20422615/79c375ec-5d7c-43d8-b81b-56b453d48a59">
