### PR TITLE
Fixed Dutch translation

### DIFF
--- a/locales/nl.json
+++ b/locales/nl.json
@@ -42,7 +42,7 @@
   "Welcome back! You've successfully signed in.": "Welkom terug! Je bent succesvol ingelogd.",
   "You've successfully subscribed to": "Je hebt je ingeschreven voor",
   "Your email address": "Je e-mailadres",
-  "of": "of",
+  "of": "van",
   "with the email address": "met het e-mailadres",
   "with this tag": "met deze tag"
 }


### PR DESCRIPTION
Fixed Dutch translation of the word 'of'.

In the context '1 of 2', 'of' is translated to 'van' -> '1 van 2'
Currently, the word 'of' is used.

The current display, '1 of 2' means '1 or 2'.