### PR TITLE
fix: #featured-bg-{{id}} not resizing Unsplash images

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -54,11 +54,11 @@ into the {body} of the default.hbs template --}}
                         {{#if feature_image}}
                           <style>
                             #featured-bg-{{id}} {
-                              background-image: url({{img_url feature_image size='l'}});
+                              background-image: url({{{img_url feature_image size='l'}}});
                             }
                             @media(max-width: 768px) {
                               #featured-bg-{{id}} {
-                                background-image: url({{img_url feature_image size='m'}});
+                                background-image: url({{{img_url feature_image size='m'}}});
                               }
                             }
                           </style>


### PR DESCRIPTION
### Problem: 

Unsplash images are not resizing properly because the CSS property `background-image` being added to `#featured-bg-{{id}}` is HTML-encoded. 

You can try this yourself by adding an Unsplash image in the Unsplash button beside the `Add feature image`
![image](https://github.com/user-attachments/assets/7f338fad-9a0d-4851-ad20-892367daeee6)

Then look at your request in the browser using liebling theme to see the HTML-encoded query, then use the Casper theme to see the proper query.
 
The HTML-encoded query string added to Unsplash URLs shows up as:

> `
crop&#x3D;entropy&amp;cs&#x3D;tinysrgb&amp;fit&#x3D;max&amp;fm&#x3D;jpg&amp;ixid&#x3D;M3wxMTc3M3wwfDF8c2VhcmNofDEwfHxhJTIwbWFuJTIwcmlkaW5nJTIwYSUyMGJpa2UlMjBkb3duJTIwYSUyMHN0cmVldCUyMG5leHQlMjB0byUyMHRhbGwlMjBidWlsZGluZ3xlbnwwfHx8fDE3MjczOTU5MDJ8MA&amp;ixlib&#x3D;rb-4.0.3&amp;q&#x3D;80&amp;w&#x3D;600
`

### Solution: 
Add a triple bracket handlebar to properly parse the text instead:

> `
crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=M3wxMTc3M3wwfDF8c2VhcmNofDEwfHxhJTIwbWFuJTIwcmlkaW5nJTIwYSUyMGJpa2UlMjBkb3duJTIwYSUyMHN0cmVldCUyMG5leHQlMjB0byUyMHRhbGwlMjBidWlsZGluZ3xlbnwwfHx8fDE3MjczOTU5MDJ8MA&ixlib=rb-4.0.3&q=80&w=320
`

### Result:

**10.4MB** Request size
![image](https://github.com/user-attachments/assets/726443d0-4a16-40f7-aac8-d86a4fb5af6b)

versus

**956KB** Request size
![image](https://github.com/user-attachments/assets/9104b74e-8e59-4615-b217-b04f176032bd)



This might save homepage first load dozens of MBs of data and shaves much time when the blog uses Unsplash. 